### PR TITLE
Change OPT_LEVEL to be &str instead of u8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "built"
-version = "0.2.3"
+version = "0.3.0"
 description = "Provides a crate with information from the time it was built."
 repository = "https://github.com/lukaslueg/built"
 documentation = "https://docs.rs/built"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,7 @@ fn write_env<T: io::Write>(envmap: &EnvironmentMap, w: &mut T) -> io::Result<()>
     write!(
         w,
         "#[doc=\"Value of OPT_LEVEL for the profile used during compilation.\"]\npub const \
-         OPT_LEVEL: u8 = {};\n",
+         OPT_LEVEL: &str = \"{}\";\n",
         env::var("OPT_LEVEL").unwrap()
     )?;
     write!(
@@ -649,7 +649,7 @@ impl Options {
     /// #[doc="The documentation generator that cargo resolved to use."]
     /// pub const RUSTDOC: &str = "rustdoc";
     /// #[doc="Value of OPT_LEVEL for the profile used during compilation."]
-    /// pub const OPT_LEVEL: u8 = 0;
+    /// pub const OPT_LEVEL: &str = "0";
     /// #[doc="The parallelism that was specified during compilation."]
     /// pub const NUM_JOBS: u32 = 8;
     /// #[doc="Value of DEBUG for the profile used during compilation."]

--- a/tests/testbox_tests.rs
+++ b/tests/testbox_tests.rs
@@ -136,7 +136,7 @@ fn main() {
     assert_eq!(built_info::PKG_DESCRIPTION, "xobtset");
     assert_eq!(built_info::PKG_HOMEPAGE, "localhost");
     assert!(built_info::NUM_JOBS > 0);
-    assert!(built_info::OPT_LEVEL == 0);
+    assert!(built_info::OPT_LEVEL == "0");
     assert!(built_info::DEBUG);
     assert_eq!(built_info::PROFILE, "debug");
     assert_eq!(built_info::FEATURES,


### PR DESCRIPTION
Closes #15.

This builds and passes tests and seems to do what you'd expect. Let me know if you'd like me to bump the version number in Cargo.toml.