### PR TITLE
No need to specify 'build.rs' in Cargo.toml anymore

### DIFF
--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -2,7 +2,6 @@
 name = "example_project"
 version = "0.1.0"
 authors = ["Lukas Lueg <lukas.lueg@gmail.com>"]
-build = "build.rs"
 
 [dependencies]
 built = { version = "^0.3", path="../" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,6 @@
 //! Add this to `Cargo.toml`:
 //!
 //! ```toml
-//! [package]
-//! build = "build.rs"
-//!
 //! [build-dependencies]
 //! built = "0.3"
 //! ```

--- a/tests/testbox_tests.rs
+++ b/tests/testbox_tests.rs
@@ -73,7 +73,6 @@ fn new_testbox() {
 name = \"testbox\"
 version = \"1.2.3-rc1\"
 authors = [\"Joe\", \"Bob\", \"Harry:Potter\"]
-build = \"build.rs\"
 description = \"xobtset\"
 homepage = \"localhost\"
 
@@ -189,7 +188,6 @@ fn empty_git() {
 [package]
 name = "testbox"
 version = "0.0.1"
-build = "build.rs"
 
 [build-dependencies]
 built = {{ path = {:?} }}"#, &built_root));


### PR DESCRIPTION
I'm pretty sure we don't need to specify the build.rs file anymore.