### PR TITLE
Add `GIT_COMMIT_HASH` and `GIT_HEAD_REF`

### DIFF
--- a/tests/testbox_tests.rs
+++ b/tests/testbox_tests.rs
@@ -128,6 +128,8 @@ mod built_info {
 
 fn main() {
     assert_eq!(built_info::GIT_VERSION, None);
+    assert_eq!(built_info::GIT_COMMIT_HASH, None);
+    assert_eq!(built_info::GIT_HEAD_REF, None);
     assert!(built_info::CI_PLATFORM.is_some());
     assert_eq!(built_info::PKG_VERSION, "1.2.3-rc1");
     assert_eq!(built_info::PKG_VERSION_MAJOR, "1");


### PR DESCRIPTION
I was wondering why `built` does not retrieve the Git commit hash of the build. I found it quite useful in some situations, as well as the author of #3.

Since `built` already reports the Git version tag, I thought, I just add the hash and in the spirit of #3 also (if any) the branch name HEAD in pointing to.