### PR TITLE
Expose repository and license from Cargo.toml

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,7 +523,11 @@ fn write_env(envmap: &EnvironmentMap, w: &mut fs::File) -> io::Result<()> {
         (PKG_DESCRIPTION, "CARGO_PKG_DESCRIPTION", "The description."),
         (PKG_HOMEPAGE, "CARGO_PKG_HOMEPAGE", "The homepage."),
         (PKG_LICENSE, "CARGO_PKG_LICENSE", "The license."),
-        (PKG_REPOSITORY, "CARGO_PKG_REPOSITORY", "The source repository as advertised in Cargo.toml."),
+        (
+            PKG_REPOSITORY,
+            "CARGO_PKG_REPOSITORY",
+            "The source repository as advertised in Cargo.toml."
+        ),
         (
             TARGET,
             "TARGET",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -488,7 +488,10 @@ fn write_env(envmap: &EnvironmentMap, w: &mut fs::File) -> io::Result<()> {
     macro_rules! write_env_str {
         ($(($name:ident, $env_name:expr,$doc:expr)),*) => {$(
             writeln!(w, "#[doc={}]\npub const {}: &str = r\"{}\";",
-                    stringify!($doc), stringify!($name), envmap.get($env_name).unwrap())?;
+                    stringify!($doc),
+                    stringify!($name),
+                    envmap.get($env_name)
+                        .expect(stringify!(Missing expected environment variable$env_name)))?;
         )*}
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,10 @@
 //! pub const PKG_DESCRIPTION: &str = "";
 //! #[doc="The homepage."]
 //! pub const PKG_HOMEPAGE: &str = "";
+//! #[doc="The license."]
+//! pub const PKG_LICENSE: &str = "MIT";
+//! #[doc="The source repository as advertised in Cargo.toml."]
+//! pub const PKG_REPOSITORY: &str = "";
 //! #[doc="The target triple that was being compiled for."]
 //! pub const TARGET: &str = "x86_64-unknown-linux-gnu";
 //! #[doc="The host triple of the rust compiler."]
@@ -518,6 +522,8 @@ fn write_env(envmap: &EnvironmentMap, w: &mut fs::File) -> io::Result<()> {
         (PKG_NAME, "CARGO_PKG_NAME", "The name of the package."),
         (PKG_DESCRIPTION, "CARGO_PKG_DESCRIPTION", "The description."),
         (PKG_HOMEPAGE, "CARGO_PKG_HOMEPAGE", "The homepage."),
+        (PKG_LICENSE, "CARGO_PKG_LICENSE", "The license."),
+        (PKG_REPOSITORY, "CARGO_PKG_REPOSITORY", "The source repository as advertised in Cargo.toml."),
         (
             TARGET,
             "TARGET",

--- a/tests/testbox_tests.rs
+++ b/tests/testbox_tests.rs
@@ -139,6 +139,8 @@ authors = [\"Joe\", \"Bob\", \"Harry:Potter\"]
 build = \"build.rs\"
 description = \"xobtset\"
 homepage = \"localhost\"
+repository = \"https://dev.example.com/sources/testbox/\"
+license = \"MIT\"
 
 [dependencies]
 chrono = \"0.4\"
@@ -199,6 +201,8 @@ fn main() {
     assert_eq!(built_info::PKG_NAME, "testbox");
     assert_eq!(built_info::PKG_DESCRIPTION, "xobtset");
     assert_eq!(built_info::PKG_HOMEPAGE, "localhost");
+    assert_eq!(built_info::PKG_LICENSE, "MIT");
+    assert_eq!(built_info::PKG_REPOSITORY, "https://dev.example.com/sources/testbox/");
     assert!(built_info::NUM_JOBS > 0);
     assert!(built_info::OPT_LEVEL == "0");
     assert!(built_info::DEBUG);


### PR DESCRIPTION
This is useful for creating lines like `"Created by {}, licensed under the terms of {}. Get the source at {}"`. (For the license terms it might be helpful to get more structured information there and parse the SPDX expression, but that's not enforced so might not be valid, and can just as well be done at runtime.)