### PR TITLE
Enhance error output on missing Cargo.lock

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,14 @@ impl CIPlatform {
 
 fn get_build_deps(manifest_location: &path::Path) -> io::Result<Vec<(String, String)>> {
     let mut lock_buf = String::new();
-    fs::File::open(manifest_location.join("Cargo.lock"))?.read_to_string(&mut lock_buf)?;
+    fs::File::open(manifest_location.join("Cargo.lock"))
+        .map_err(|i| {
+            std::io::Error::new(
+                i.kind(),
+                "No Cargo.lock file found, see set_dependencies documentation",
+            )
+        })?
+        .read_to_string(&mut lock_buf)?;
     Ok(parse_dependencies(&lock_buf))
 }
 


### PR DESCRIPTION
This changes the previously generic error ("File not found") to produce this when a library crate uses built's set_dependencies gets built:

```
error: failed to run custom build command for `leafcrate v0.1.0 (/tmp/leafcrate)`

Caused by:
  process didn't exit successfully: `/tmp/leafcrate/target/debug/build/leafcrate-1c09147a939b59c4/build-script-build` (exit code: 101)
  --- stderr
  thread 'main' panicked at 'Failed to acquire build-time information: Custom { kind: NotFound, error: "No Cargo.lock file found, see set_dependencies documentation" }', build.rs:9:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Contributes-To: https://github.com/lukaslueg/built/issues/32