### PR TITLE
Add allow(dead_code) to variables

### DIFF
--- a/example_project/src/main.rs
+++ b/example_project/src/main.rs
@@ -1,5 +1,5 @@
 // The file `built.rs` was placed there by cargo and `build.rs`
-pub mod built_info {
+mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ macro_rules! write_variable {
     ($writer:expr, $name:expr, $datatype:expr, $value:expr, $doc:expr) => {
         writeln!(
             $writer,
-            "#[doc=\"{}\"]\npub const {}: {} = {};",
+            "#[doc=\"{}\"]\n#[allow(dead_code)]\npub const {}: {} = {};",
             $doc, $name, $datatype, $value
         )?;
     };


### PR DESCRIPTION
This change creates a macro to simplify writing variables, and allows the variables to be unused. This permits the file to be included without declaring it public.
