### PR TITLE
remove unused transitive dependency to `time 0.1`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ nightly = []
 [dependencies]
 cargo-lock = { version = "7.0", default-features = false }
 semver = { version = "1.0", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
 git2 = { version = "0.13", optional = true, default-features = false, features = [] }
 
 [dev-dependencies]


### PR DESCRIPTION
`built` does not use the `time 0.1` `Duration`, so there is no need to transitivly depend on the old version of that crate.