### PR TITLE
Update example to work with resolver 2

### DIFF
--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -4,9 +4,10 @@ version = "0.1.0"
 authors = ["Lukas Lueg <lukas.lueg@gmail.com>"]
 build = "build.rs"
 edition = "2018"
+resolver = "2"
 
 [dependencies]
-built = { version = "0.5", path="../", features = ["git2", "chrono", "semver"] }
+built = { version = "0.5", path="../", features = ["chrono", "semver"] }
 
 [build-dependencies]
-built = { version = "0.5", path="../" }
+built = { version = "0.5", path="../", features = ["git2", "chrono", "semver"] }

--- a/example_project/Cargo.toml
+++ b/example_project/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 authors = ["Lukas Lueg <lukas.lueg@gmail.com>"]
 build = "build.rs"
 edition = "2018"
-resolver = "2"
 
 [dependencies]
 built = { version = "0.5", path="../", features = ["chrono", "semver"] }


### PR DESCRIPTION
With `resolver = "2"` (default in 2021 Edition), features need to be specified explicitly for build dependencies, otherwise when `build.rs` is run, it doesn't generate feature-gated values.