### PR TITLE
Add `gitoxide` feature

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,12 @@ jobs:
         with:
           command: clippy
           args: --all --tests -- -D warnings
-      - name: Clippy with all features
+      - name: Clippy with all features (git2)
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features=chrono,git2,semver --all --tests -- -D warnings
+      - name: Clippy with all features (gitoxide)
         uses: actions-rs/cargo@v1
         with:
           command: clippy
@@ -66,7 +71,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: Test with all features
+      - name: Test with all features (git2)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features=chrono,git2,semver
+      - name: Test with all features (gitoxide)
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,14 @@ edition = "2021"
 
 [features]
 nightly = []
-gitoxide = ["git-repository", "git2"]
+gitoxide = ["gix", "git2"]
 
 [dependencies]
 cargo-lock = { version = "8.0", default-features = false }
 semver = { version = "1.0", optional = true }
 chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
 git2 = { version = "0.16", optional = true, default-features = false, features = [] }
-git-repository = { version = "0.34.0", optional = true, default-features = false, features = ["max-performance-safe"] }
+gix = { version = "0.43.1", optional = true, default-features = false, features = ["max-performance-safe"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,17 @@ edition = "2021"
 
 [features]
 nightly = []
+gitoxide = ["git-repository", "git2"]
 
 [dependencies]
 cargo-lock = { version = "8.0", default-features = false }
 semver = { version = "1.0", optional = true }
 chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
 git2 = { version = "0.16", optional = true, default-features = false, features = [] }
+git-repository = { version = "0.34.0", optional = true, default-features = false, features = ["max-performance-safe"] }
 
 [dev-dependencies]
 tempfile = "3"
 
 [package.metadata.docs.rs]
-features = [ "chrono", "git2", "semver" ]
+features = [ "chrono", "git2", "gitoxide", "semver" ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,3 +27,4 @@ build: false
 test_script:
   - cargo build --verbose
   - cargo test --verbose --features chrono,git2,semver
+  - cargo test --verbose --features chrono,gitoxide,semver

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,7 +716,7 @@ fn write_cfg(w: &mut fs::File) -> io::Result<()> {
 #[allow(dead_code, unused_imports, unused_variables)]
 mod gitoxide_impls {
     use crate::fmt_option_str;
-    use git_repository as git;
+    use gix;
     use std::{fs, io, io::Write, path};
 
     // NOTE: There are a few opportunities to make this code more maintainable by refactoring / deduplicating, but I wanted
@@ -732,7 +732,7 @@ mod gitoxide_impls {
     }
 
     fn get_repo_info(manifest_location: &path::Path) -> Option<RepoInfo> {
-        let repo = git::discover(manifest_location).ok()?;
+        let repo = gix::discover(manifest_location).ok()?;
 
         let branch = repo.head_name().ok()?.map(|n| n.to_string());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,7 +427,7 @@ fn fmt_option_str<S: fmt::Display>(o: Option<S>) -> String {
     }
 }
 
-#[cfg(feature = "git2")]
+#[cfg(all(feature = "git2", not(feature = "gitoxide")))]
 fn write_git_version(manifest_location: &path::Path, w: &mut fs::File) -> io::Result<()> {
     // CIs will do shallow clones of repositories, causing libgit2 to error
     // out. We try to detect if we are running on a CI and ignore the
@@ -712,6 +712,221 @@ fn write_cfg(w: &mut fs::File) -> io::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "gitoxide")]
+#[allow(dead_code, unused_imports, unused_variables)]
+mod gitoxide_impls {
+    use crate::fmt_option_str;
+    use git_repository as git;
+    use std::{fs, io, io::Write, path};
+
+    // NOTE: There are a few opportunities to make this code more maintainable by refactoring / deduplicating, but I wanted
+    // to keep it simple to showcase the changes in the most simple way. Happy to adjust this once this PR moves further.
+
+    #[derive(Debug, Default, PartialEq)]
+    struct RepoInfo {
+        branch: Option<String>,
+        tag: Option<String>,
+        dirty: Option<bool>,
+        commit_id: Option<String>,
+        commit_id_short: Option<String>,
+    }
+
+    fn get_repo_info(manifest_location: &path::Path) -> Option<RepoInfo> {
+        let repo = git::discover(manifest_location).ok()?;
+
+        let branch = repo.head_name().ok()?.map(|n| n.to_string());
+
+        let repo_info = if let Ok(commit) = repo.head_commit() {
+            RepoInfo {
+                branch,
+                tag: commit.describe().format().ok().map(|f| f.to_string()),
+                dirty: is_dirty(manifest_location),
+                commit_id: Some(commit.id().to_string()),
+                commit_id_short: commit.id().shorten().ok().map(|p| p.to_string()),
+            }
+        } else {
+            RepoInfo {
+                branch,
+                ..Default::default()
+            }
+        };
+
+        Some(repo_info)
+    }
+
+    // TODO: replace git2 with gitoxide once this functionality becomes available in git-repository.
+    fn is_dirty(manifest_location: &path::Path) -> Option<bool> {
+        let mut options = git2::StatusOptions::new();
+        options.include_ignored(false);
+        options.include_untracked(false);
+
+        let dirty = git2::Repository::discover(manifest_location)
+            .ok()?
+            .statuses(Some(&mut options))
+            .ok()?
+            .iter()
+            .any(|status| !matches!(status.status(), git2::Status::CURRENT));
+
+        Some(dirty)
+    }
+
+    pub(crate) fn write_git_version(
+        manifest_location: &path::Path,
+        w: &mut fs::File,
+    ) -> io::Result<()> {
+        let info = get_repo_info(manifest_location).unwrap_or_default();
+
+        write_variable!(
+            w,
+            "GIT_VERSION",
+            "Option<&str>",
+            fmt_option_str(info.tag),
+            "If the crate was compiled from within a git-repository, \
+            `GIT_VERSION` contains HEAD's tag. The short commit id is used if HEAD is not tagged."
+        );
+        write_variable!(
+            w,
+            "GIT_DIRTY",
+            "Option<bool>",
+            match info.dirty {
+                Some(true) => "Some(true)",
+                Some(false) => "Some(false)",
+                None => "None",
+            },
+            "If the repository had dirty/staged files."
+        );
+
+        let doc = "If the crate was compiled from within a git-repository, `GIT_HEAD_REF` \
+        contains full name to the reference pointed to by HEAD \
+        (e.g.: `refs/heads/master`). If HEAD is detached or the branch name is not \
+        valid UTF-8 `None` will be stored.\n";
+        write_variable!(
+            w,
+            "GIT_HEAD_REF",
+            "Option<&str>",
+            fmt_option_str(info.branch),
+            doc
+        );
+
+        write_variable!(
+            w,
+            "GIT_COMMIT_HASH",
+            "Option<&str>",
+            fmt_option_str(info.commit_id),
+            "If the crate was compiled from within a git-repository, `GIT_COMMIT_HASH` \
+    contains HEAD's full commit SHA-1 hash."
+        );
+
+        write_variable!(
+            w,
+            "GIT_COMMIT_HASH_SHORT",
+            "Option<&str>",
+            fmt_option_str(info.commit_id_short),
+            "If the crate was compiled from within a git-repository, `GIT_COMMIT_HASH_SHORT` \
+    contains HEAD's short commit SHA-1 hash."
+        );
+
+        Ok(())
+    }
+
+    // NOTE: Copy-pasted test and replaced functions from `util::*` with `gitoxide_impls::get_repo_info`.
+
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn parse_git_repo() {
+            use std::fs;
+            use std::path;
+
+            let repo_root = tempfile::tempdir().unwrap();
+            assert_eq!(super::get_repo_info(repo_root.as_ref()), None);
+
+            let repo = git2::Repository::init_opts(
+                &repo_root,
+                git2::RepositoryInitOptions::new()
+                    .external_template(false)
+                    .mkdir(false)
+                    .no_reinit(true)
+                    .mkpath(false),
+            )
+            .unwrap();
+
+            let cruft_file = repo_root.path().join("cruftfile");
+            std::fs::write(&cruft_file, "Who? Me?").unwrap();
+
+            let project_root = repo_root.path().join("project_root");
+            fs::create_dir(&project_root).unwrap();
+
+            let sig = git2::Signature::now("foo", "bar").unwrap();
+            let mut idx = repo.index().unwrap();
+            idx.add_path(path::Path::new("cruftfile")).unwrap();
+            idx.write().unwrap();
+            let commit_oid = repo
+                .commit(
+                    Some("HEAD"),
+                    &sig,
+                    &sig,
+                    "Testing testing 1 2 3",
+                    &repo.find_tree(idx.write_tree().unwrap()).unwrap(),
+                    &[],
+                )
+                .unwrap();
+
+            let binding = repo
+                .find_commit(commit_oid)
+                .unwrap()
+                .into_object()
+                .short_id()
+                .unwrap();
+
+            let commit_oid_short = binding.as_str().unwrap();
+
+            let commit_hash = format!("{}", commit_oid);
+            let commit_hash_short = commit_oid_short.to_string();
+
+            assert!(commit_hash.starts_with(&commit_hash_short));
+
+            // The commit, the commit-id is something and the repo is not dirty
+            let repo_info = super::get_repo_info(&project_root).unwrap();
+            assert!(!repo_info.tag.unwrap().is_empty());
+            assert_eq!(repo_info.dirty, Some(false));
+
+            // Tag the commit, it should be retrieved
+            repo.tag(
+                "foobar",
+                &repo
+                    .find_object(commit_oid, Some(git2::ObjectType::Commit))
+                    .unwrap(),
+                &sig,
+                "Tagged foobar",
+                false,
+            )
+            .unwrap();
+
+            let repo_info = super::get_repo_info(&project_root).unwrap();
+            assert_eq!(repo_info.tag, Some(String::from("foobar")));
+            assert_eq!(repo_info.dirty, Some(false));
+
+            // Make some dirt
+            std::fs::write(cruft_file, "now dirty").unwrap();
+            let repo_info = super::get_repo_info(&project_root).unwrap();
+            assert_eq!(repo_info.tag, Some(String::from("foobar")));
+            assert_eq!(repo_info.dirty, Some(true));
+
+            let branch_short_name = "baz";
+            let branch_name = "refs/heads/baz";
+            let commit = repo.find_commit(commit_oid).unwrap();
+            repo.branch(branch_short_name, &commit, true).unwrap();
+            repo.set_head(branch_name).unwrap();
+
+            let repo_info = super::get_repo_info(&project_root).unwrap();
+            assert_eq!(repo_info.branch, Some(branch_name.to_owned()));
+            assert_eq!(repo_info.commit_id, Some(commit_hash));
+            assert_eq!(repo_info.commit_id_short, Some(commit_hash_short));
+        }
+    }
+}
+
 /// Selects which information `built` should retrieve and write as Rust code.
 /// Used in conjunction with [`write_built_file_with_opts`][wrt].
 ///
@@ -789,7 +1004,7 @@ impl Options {
     /// result. `GIT_VERSION` and `GIT_DIRTY` will therefor always be `None` if
     /// a CI-platform is detected.
     ///
-    #[cfg(feature = "git2")]
+    #[cfg(any(feature = "git2", feature = "gitoxide"))]
     pub fn set_git(&mut self, enabled: bool) -> &mut Self {
         self.git = enabled;
         self
@@ -979,9 +1194,16 @@ pub fn write_built_file_with_opts(
                 &mut built_file
             )?
         );
-        #[cfg(feature = "git2")]
+        #[cfg(all(feature = "git2", not(feature = "gitoxide")))]
         {
             o!(git, write_git_version(manifest_location, &mut built_file)?);
+        }
+        #[cfg(feature = "gitoxide")]
+        {
+            o!(
+                git,
+                gitoxide_impls::write_git_version(manifest_location, &mut built_file)?
+            );
         }
     }
     o!(
@@ -1022,7 +1244,7 @@ pub fn write_built_file() -> io::Result<()> {
 mod tests {
 
     #[test]
-    #[cfg(feature = "git2")]
+    #[cfg(all(feature = "git2", not(feature = "gitoxide")))]
     fn parse_git_repo() {
         use super::util;
         use std::fs;
@@ -1120,7 +1342,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "git2")]
+    #[cfg(all(feature = "git2", not(feature = "gitoxide")))]
     fn detached_head_repo() {
         let repo_root = tempfile::tempdir().unwrap();
         let repo = git2::Repository::init_opts(

--- a/src/util.rs
+++ b/src/util.rs
@@ -66,7 +66,7 @@ pub fn strptime(s: &str) -> chrono::DateTime<chrono::offset::Utc> {
 ///
 /// # Errors
 /// Errors from `git2` are returned if the repository does exists at all.
-#[cfg(feature = "git2")]
+#[cfg(all(feature = "git2", not(feature = "gitoxide")))]
 pub fn get_repo_description(root: &std::path::Path) -> Result<Option<(String, bool)>, git2::Error> {
     match git2::Repository::discover(root) {
         Ok(repo) => {
@@ -104,7 +104,7 @@ pub fn get_repo_description(root: &std::path::Path) -> Result<Option<(String, bo
 ///
 /// # Errors
 /// Errors from `git2` are returned if the repository does exists at all.
-#[cfg(feature = "git2")]
+#[cfg(all(feature = "git2", not(feature = "gitoxide")))]
 pub fn get_repo_head(
     root: &std::path::Path,
 ) -> Result<Option<(Option<String>, String, String)>, git2::Error> {


### PR DESCRIPTION
Hi there,

We saw that `built` depends on the `git2` crate to populate some of its `GIT_*` related variables. Have you considered using [`gitoxide`](https://github.com/byron/gitoxide/) for that purpose?

In general, `gitoxide` aims to provide the same functionality as `git2` (and much more beyond that). It is built entirely in rust from the ground up, with a high focus on correctness, usability, and performance.

**Benefits**

- `gitoxide` is generally faster than `git2` and uses fewer system resources.
- `gitoxide` aims to offer more git functionality than `git2`.
- `gitoxide` offers a friendlier API interface and documentation.
- `git-repository` with its `max-performance-safe` feature does not depend on any C build tooling / libraries.
- Direct participation in upstream improvements or feature requests.
- Direct support from @byron and myself until `gitoxide`'s first major release.

**Considerations**

- Currently, `gitoxide` is still missing the capability of doing a diff between worktree and index (aka `git status`). However, this feature will be available within the first half of 2023.
- Compile times for `built` with `gitoxide` will be higher, as for the moment `git2` is still required for `git status` functionality. This will change and compile times should be about the same as soon as `git status` is available in `gitoxide`.

**Request for Feedback**

I went ahead and added an implementation for `gitoxide` behind a feature toggle to show what it could look like. 
There are a few opportunities to refactor and make this code more maintainable, but I first wanted to showcase the changes in a more simple way and I would be happy to adjust this if this PR moves along.

I would appreciate your feedback if there is any interest in integrating `gitoxide` into `built`, and if not I am also happy to close this PR.

Thank you for your time
