### PR TITLE
Update git2 to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ nightly = []
 cargo-lock = { version = "8.0", default-features = false }
 semver = { version = "1.0", optional = true }
 chrono = { version = "0.4", optional = true, default-features = false, features = ["clock"] }
-git2 = { version = "0.16", optional = true, default-features = false, features = [] }
+git2 = { version = "0.17", optional = true, default-features = false, features = [] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Updating to the git2 crate in a different dependency will conflict with version 0.6.0. The error message is as follows:

```
~/w/trane-cli ❯❯❯ cargo upgrade                                                                                           master
    Updating 'https://github.com/rust-lang/crates.io-index' index
Error: Invalid manifest

Caused by:
    `cargo metadata` exited with an error:     Updating crates.io index
    error: failed to select a version for `libgit2-sys`.
        ... required by package `git2 v0.16.0`
        ... which satisfies dependency `git2 = "^0.16"` of package `built v0.6.0`
        ... which satisfies dependency `built = "^0.6.0"` of package `trane-cli v0.14.4 (/home/martinmr/workspace/trane-cli)`
    versions that meet the requirements `^0.14.1` are: 0.14.2+1.5.1, 0.14.1+1.5.0

    the package `libgit2-sys` links to the native library `git2`, but it conflicts with a previous package which links to `git2` as well:
    package `libgit2-sys v0.15.2+1.6.4`
        ... which satisfies dependency `libgit2-sys = "^0.15.2"` of package `git2 v0.17.2`
        ... which satisfies dependency `git2 = "^0.17.2"` of package `trane v0.14.4`
        ... which satisfies dependency `trane = "^0.14.4"` of package `trane-cli v0.14.4 (/home/martinmr/workspace/trane-cli)`
    Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the links ='libgit2-sys' value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

    failed to select a version for `libgit2-sys` which could resolve this conflict
```