### PR TITLE
Add feature to allow not including cargo environment variables in built information.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added 
+- Added feature 'skip-environment' which causes the cargo environment variables to not be written out
 
 ## [0.7.1] - 2023-10-14
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ tempfile = "3"
 dependency-tree = [ "cargo-lock/dependency-tree" ]
 
 [package.metadata.docs.rs]
-features = [ "cargo-lock", "chrono", "dependency-tree", "git2", "semver" ]
+features = [ "cargo-lock", "chrono", "dependency-tree", "git2", "semver", "skip-environment" ]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ provide that to the crate. The information collected by `built` include:
 
 * Various metadata like version, authors, homepage etc. as set by `Cargo.toml`
 * The tag or commit id if the crate was being compiled from within a Git repository.
-* The values of `CARGO_CFG_*` build script environment variables, like `CARGO_CFG_TARGET_OS` and `CARGO_CFG_TARGET_ARCH`.
+* The values of `CARGO_CFG_*` build script environment variables, like `CARGO_CFG_TARGET_OS` and `CARGO_CFG_TARGET_ARCH` (unless feature `skip-environment` is specified).
 * The features the crate was compiled with.
 * The various dependencies, dependencies of dependencies and their versions Cargo ultimately chose to compile.
 * The presence of a CI-platform like `Github Actions`, `Travis CI` and `AppVeyor`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,7 +366,10 @@ pub fn write_built_file_with_opts(
 
     let envmap = environment::EnvironmentMap::new();
     envmap.write_ci(&built_file)?;
+
+    #[cfg(not (feature = "skip-environment"))]
     envmap.write_env(&built_file)?;
+
     envmap.write_features(&built_file)?;
     envmap.write_compiler_version(&built_file)?;
     envmap.write_cfg(&built_file)?;


### PR DESCRIPTION
When using non-cargo tools to build crates (like crate2nix) the cargo environment variables are not present and cause built to panic.

An alternative to adding this feature would be to fix the panic and just not include the variables if the are not present.

fixes #62 