### PR TITLE
Don't panic if rustdoc is missing

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -235,7 +235,7 @@ impl EnvironmentMap {
         let rustdoc = &self.0["RUSTDOC"];
 
         let rustc_version = get_version_from_cmd(rustc.as_ref())?;
-        let rustdoc_version = get_version_from_cmd(rustdoc.as_ref()).unwrap_or("NOT FOUND".to_string());
+        let rustdoc_version = get_version_from_cmd(rustdoc.as_ref()).unwrap_or_default();
 
         let doc = format!("The output of `{rustc} -V`");
         write_str_variable!(w, "RUSTC_VERSION", rustc_version, doc);

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -235,7 +235,7 @@ impl EnvironmentMap {
         let rustdoc = &self.0["RUSTDOC"];
 
         let rustc_version = get_version_from_cmd(rustc.as_ref())?;
-        let rustdoc_version = get_version_from_cmd(rustdoc.as_ref())?;
+        let rustdoc_version = get_version_from_cmd(rustdoc.as_ref()).unwrap_or("NOT FOUND".to_string());
 
         let doc = format!("The output of `{rustc} -V`");
         write_str_variable!(w, "RUSTC_VERSION", rustc_version, doc);


### PR DESCRIPTION
I came here through [a rav1e issue](https://github.com/xiph/rav1e/issues/3369) and [a built issue](https://github.com/lukaslueg/built/issues/14) when trying to build [image](https://crates.io/crates/image) in a minimal container that doesn't have rustdoc installed; specifically one based on [cgr.dev/chainguard/rust:latest](https://images.chainguard.dev/directory/image/rust/versions).

The error can be produced with the following steps:

1. `cargo new broken`
2. Add the following to `Cargo.toml`:
 ```toml
[dependencies.rav1e]
version = "0.7.1"
default-features = false
```
3. Create a `Dockerfile` like
```Dockerfile
FROM cgr.dev/chainguard/rust:latest
WORKDIR /work
COPY Cargo.toml .
COPY src/ src/
RUN cargo build
```
4. Run `podman build -t broken .` and receive output like  
> error: failed to run custom build command for `rav1e v0.7.1`
>
>Caused by:
>  process didn't exit successfully: `/work/target/debug/build/rav1e-630d2ba1731d92a3/build-script->build` (exit status: 101)
>  --- stderr
>  thread 'main' panicked at /home/nonroot/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rav1e-0.7.1/build.rs:250:29:
>  Failed to acquire build-time information: Os { code: 2, kind: NotFound, message: "No such file or directory" }
>  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
Error: building at STEP "RUN cargo build": while running runtime: exit status 101

To see that the patch eliminates the issue, the steps are similar:

1. `cargo new fixed` 
2. Add `built` with the patch applied somewhere reachable by the coming container build context, e.g. `rsync -a /path/to/built/ fixed/`
3.  Add the dependency as in `broken`, and also
```toml
[patch.crates-io]
built = { path = "./built" }
```
4. Add it to the `Dockerfile` like 
```Dockerfile
FROM cgr.dev/chainguard/rust:latest
WORKDIR /work
COPY Cargo.toml .
COPY src/ src/
COPY built/ built/
RUN cargo build
```
5. Run `podman build -t fixed .` and see that the build completes successfully.

I don't have any particular opinion about what built should output when rustdoc is missing; my goal here is to successfully build a minimal container image using the image crate.