### PR TITLE
fix: Documentation for `OPT_LEVEL` emits clippy warning

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -221,7 +221,7 @@ impl EnvironmentMap {
             "OPT_LEVEL",
             self.get_override_var("OPT_LEVEL")
                 .unwrap_or_else(|| env::var("OPT_LEVEL").unwrap()),
-            "Value of OPT_LEVEL for the profile used during compilation."
+            "Value of `OPT_LEVEL` for the profile used during compilation."
         );
 
         write_variable!(


### PR DESCRIPTION
I'm getting a clippy warning on new versions of rust when clippy is being pedantic
```
   |
73 | #[doc=r#"Value of OPT_LEVEL for the profile used during compilation."#]
   |                   ^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_markdown
   = note: `-D clippy::doc-markdown` implied by `-D clippy::pedantic`
   = help: to override `-D clippy::pedantic` add `#[allow(clippy::doc_markdown)]`
help: try
   |
73 - #[doc=r#"Value of OPT_LEVEL for the profile used during compilation."#]
73 + #[doc=r#"Value of `OPT_LEVEL` for the profile used during compilation."#]
```
This just applies the suggested fix.