### PR TITLE
update documentation related to PKG_* to include 'VERSION'

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,16 +178,16 @@
 //! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_VERSION`.
 //! pub static PKG_VERSION: &str = "0.1.0";
 //! /// The major version.
-//! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_MAJOR`.
+//! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_VERSION_MAJOR`.
 //! pub static PKG_VERSION_MAJOR: &str = "0";
 //! /// The minor version.
-//! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_MINOR`.
+//! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_VERSION_MINOR`.
 //! pub static PKG_VERSION_MINOR: &str = "1";
 //! /// "The patch version.
-//! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_PATCH`.
+//! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_VERSION_PATCH`.
 //! pub static PKG_VERSION_PATCH: &str = "0";
 //! /// "The pre-release version.
-//! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_PRE`.
+//! /// Can be overridden with `BUILT_OVERRIDE_{pkg_name}_PKG_VERSION_PRE`.
 //! pub static PKG_VERSION_PRE: &str = "";
 //!
 //! /// "A colon-separated list of authors.


### PR DESCRIPTION
Hello!

I've only experienced this for `PKG_PATCH` which would lead to the following warning:

```
At least one environment variable looks like an override-variable but was ignored by built: `BUILT_OVERRIDE_my_pkg_PKG_PATCH`. Typo?"
```

Using `BUILT_OVERRIDE_my_pkg_PKG_VERSION_PATCH` fixes the problem; and I assumed other fields would follow the same rule.
